### PR TITLE
Disable linkintegrity checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
   [gbastien]
 - Added parameter `disable_linkintegrity_checks=False` to `Migrator.__init__`
   so it is easier to disable linkintegrity checks during a migration.
+  Supposed to work with Plone4 and Plone5...
   [gbastien]
 
 1.9 (2019-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Changelog
   [gbastien]
 - Requires `imio.helpers`.
   [gbastien]
+- Added parameter `disable_linkintegrity_checks=False` to `Migrator.__init__`
+  so it is easier to disable linkintegrity checks during a migration.
+  [gbastien]
 
 1.9 (2019-01-17)
 ----------------

--- a/src/imio/migrator/migrator.py
+++ b/src/imio/migrator/migrator.py
@@ -8,14 +8,14 @@
 from imio.helpers.catalog import removeColumns
 from imio.helpers.catalog import removeIndexes
 from plone import api
+from plone.app.controlpanel.editing import IEditingSchema
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.interfaces import IPropertiesTool
 from Products.CMFPlone.utils import base_hasattr
 from Products.GenericSetup.upgrade import normalize_version
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from zope.component import getUtility
 from zope.component import queryUtility
-from Products.CMFCore.interfaces import IPropertiesTool
-from plone.app.controlpanel.editing import IEditingSchema
 
 import logging
 import time


### PR DESCRIPTION
Salut @sgeulette @bsuttor 

j'ai ajouté le paramètre "disable_linkintegrity_checks=False" dans Migrator.__init__ afin que çà prenne en charge le fait de désactiver link integrity.  En général c'est refait dans chacune des sous-classes des différents projets, j'en avais marre de devoir le faire à nouveau ;-)

La question c'est =False ou =True par défaut...  Avec un =False, çà ne change rien par rapport à ce qui existait avant...

Merci!

Gauthier